### PR TITLE
fix(links): change linkedin user handle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,7 +103,7 @@ author:
   instagram        :
   impactstory      : #"https://profiles.impactstory.org/u/xxxx-xxxx-xxxx-xxxx"
   lastfm           :
-  linkedin         : "https://www.linkedin.com/in/fabian-david-schmidt-111a3197/"
+  linkedin         : "fabian-david-schmidt-111a3197"
   orcid            : 
   pinterest        :
   soundcloud       :


### PR DESCRIPTION
LinkedIn helper expects a user handle, not a complete url. This should fix the link in your sidebar.

Cheers! 🍻